### PR TITLE
fix SECONDFPN missing from model registry and specify pytorch-lightning version in requirements.txt (#11, #12, #13) 

### DIFF
--- a/layers/heads/bev_depth_head.py
+++ b/layers/heads/bev_depth_head.py
@@ -4,7 +4,8 @@ from mmdet3d.core import draw_heatmap_gaussian, gaussian_radius
 from mmdet3d.models.dense_heads.centerpoint_head import CenterHead
 from mmdet3d.models.utils import clip_sigmoid
 from mmdet.core import reduce_mean
-from mmdet.models import build_backbone, build_neck
+from mmdet.models import build_backbone
+from mmdet3d.models import build_neck
 from torch.cuda.amp import autocast
 
 __all__ = ['BEVDepthHead']

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy
 nuscenes-devkit
 opencv-python-headless
 pandas
-pytorch-lightning
+pytorch-lightning==1.5.10
 scikit-image
 scipy
 tensorboardX


### PR DESCRIPTION
importing build_neck from mmdet causes error:  
`'SECONDFPN is not in the model registry''`

importing build_neck from mmdet3d fixes this.

The latest PyTorch lightning version causes issues #12 and #13. Downgrading to 1.5.10 fixes this, so I added it to requirements.txt