### PR TITLE
support pytorch 1.11+

### DIFF
--- a/ops/voxel_pooling/src/voxel_pooling_forward.cpp
+++ b/ops/voxel_pooling/src/voxel_pooling_forward.cpp
@@ -1,13 +1,11 @@
 // Copyright (c) Megvii Inc. All rights reserved.
-#include <THC/THC.h>
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 #include <torch/extension.h>
 #include <torch/serialize/tensor.h>
+#include <ATen/cuda/CUDAContext.h>
 
 #include <vector>
-
-extern THCState *state;
 
 #define CHECK_CUDA(x) \
   TORCH_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")


### PR DESCRIPTION
As of pytorch 11 THC is no longer used. Switch to ATen so voxel pooling can be compiled with pytorch 11 (still backward compatible with pytorch 1.9).