### PR TITLE
fix `visualize_nusc`

### DIFF
--- a/bevdepth/exps/base_exp.py
+++ b/bevdepth/exps/base_exp.py
@@ -2,6 +2,7 @@
 from functools import partial
 
 import mmcv
+import os
 import torch
 import torch.nn.functional as F
 import torch.nn.parallel
@@ -227,9 +228,9 @@ class BEVDepthLightningModel(LightningModule):
         self.depth_channels = int(
             (self.dbound[1] - self.dbound[0]) / self.dbound[2])
         self.use_fusion = False
-        self.train_info_paths = 'data/nuScenes/nuscenes_infos_train.pkl'
-        self.val_info_paths = 'data/nuScenes/nuscenes_infos_val.pkl'
-        self.predict_info_paths = 'data/nuScenes/nuscenes_infos_test.pkl'
+        self.train_info_paths = os.path.join(self.data_root, 'nuscenes_infos_train.pkl')    
+        self.val_info_paths = os.path.join(self.data_root, 'nuscenes_infos_val.pkl')
+        self.predict_info_paths = os.path.join(self.data_root, 'nuscenes_infos_test.pkl')
 
     def forward(self, sweep_imgs, mats):
         return self.model(sweep_imgs, mats)

--- a/scripts/visualize_nusc.py
+++ b/scripts/visualize_nusc.py
@@ -1,6 +1,7 @@
 import os
 from argparse import ArgumentParser
 
+import cv2
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
 import mmcv
@@ -8,8 +9,7 @@ import numpy as np
 from nuscenes.utils.data_classes import Box, LidarPointCloud
 from pyquaternion import Quaternion
 
-from datasets.nusc_det_dataset import map_name_from_general_to_detection
-
+from bevdepth.datasets.nusc_det_dataset import map_name_from_general_to_detection
 
 def parse_args():
     parser = ArgumentParser(add_help=False)
@@ -213,6 +213,8 @@ def demo(
 
         img = mmcv.imread(
             os.path.join('data/nuScenes', info['cam_infos'][k]['filename']))
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+
         # Draw images
         plt.imshow(img)
 


### PR DESCRIPTION
Congrats on this great work! This PR includes several minor changes:
- fix import path in `scripts/visualize_nusc.py`
- fix image display, you can see the camera RGB is not displayed correctly in https://github.com/Megvii-BaseDetection/BEVDepth/issues/90#issuecomment-1289970693 (ref: https://stackoverflow.com/questions/54959387/rgb-image-display-in-matplotlib-plt-imshow-returns-a-blue-image)
- refactor `BEVDepthLightningModel` to use `data_root` to infer path of `nuscenes_infos*.pkl`

